### PR TITLE
phpのバイナリを指定するよう変更(windows環境に対応)

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -65,6 +65,10 @@ const settings = {
   ftpHost: process.env.FTP_HOST,
   ftpPort: process.env.FTP_PORT,
 }
+
+// phpの実行ファイルへの絶対パスを指定
+const phpPath = 'C:/PATH/TO/YOUR/php.exe'
+
 // setting update
 const argv = minimist(process.argv.slice(2))
 for (const key in argv) {
@@ -309,7 +313,8 @@ export const sync = (done) => {
   gulpConnect.server({
     port: settings.port,
     base: settings.srcDir,
-    stdio: 'ignore'
+    stdio: 'ignore',
+    bin: phpPath
   }, () => {
     browserSync.init({
       proxy: `localhost:${settings.port}`

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -67,11 +67,13 @@ const settings = {
 }
 
 /**
- * phpPath
- * windowsまたはphpのバージョンを指定したい場合はpathを指定
- * 例：const phpPath = 'C:/PATH/TO/YOUR/php.exe'
+ * phpPathは環境に合わせてどちらかをコメントアウトする
  */
+// mac,linuxで既にphpがインストールしてある場合
 const phpPath = undefined
+
+// windowsまたはphpのバージョンを指定したい場合
+// const phpPath = 'C:/PATH/TO/YOUR/php.exe'
 
 // setting update
 const argv = minimist(process.argv.slice(2))
@@ -314,13 +316,12 @@ export const dist = gulp.series(removeDistDir, copy, css, js)
  * sync終了後もportが閉じない場合に利用
  */
 export const sync = (done) => {
-  const gulpConnectOption = {
+  gulpConnect.server({
     port: settings.port,
     base: settings.srcDir,
-    stdio: 'ignore'
-  }
-  if (phpPath) gulpConnectOption.bin(phpPath)
-  gulpConnect.server(gulpConnectOption, () => {
+    stdio: 'ignore',
+    bin: phpPath
+  }, () => {
     browserSync.init({
       proxy: `localhost:${settings.port}`
     })

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -67,13 +67,11 @@ const settings = {
 }
 
 /**
- * phpPathは環境に合わせてどちらかをコメントアウトする
+ * phpPath
+ * windowsまたはphpのバージョンを指定したい場合はpathを指定
+ * 例：const phpPath = 'C:/PATH/TO/YOUR/php.exe'
  */
-// mac,linuxで既にphpがインストールしてある場合
 const phpPath = undefined
-
-// windowsまたはphpのバージョンを指定したい場合
-// const phpPath = 'C:/PATH/TO/YOUR/php.exe'
 
 // setting update
 const argv = minimist(process.argv.slice(2))
@@ -316,12 +314,13 @@ export const dist = gulp.series(removeDistDir, copy, css, js)
  * sync終了後もportが閉じない場合に利用
  */
 export const sync = (done) => {
-  gulpConnect.server({
+  const gulpConnectOption = {
     port: settings.port,
     base: settings.srcDir,
-    stdio: 'ignore',
-    bin: phpPath
-  }, () => {
+    stdio: 'ignore'
+  }
+  if (phpPath) gulpConnectOption.bin(phpPath)
+  gulpConnect.server(gulpConnectOption, () => {
     browserSync.init({
       proxy: `localhost:${settings.port}`
     })

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -66,8 +66,14 @@ const settings = {
   ftpPort: process.env.FTP_PORT,
 }
 
-// phpの実行ファイルへの絶対パスを指定
-const phpPath = 'C:/PATH/TO/YOUR/php.exe'
+/**
+ * phpPathは環境に合わせてどちらかをコメントアウトする
+ */
+// mac,linuxで既にphpがインストールしてある場合
+const phpPath = undefined
+
+// windowsまたはphpのバージョンを指定したい場合
+// const phpPath = 'C:/PATH/TO/YOUR/php.exe'
 
 // setting update
 const argv = minimist(process.argv.slice(2))

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -67,13 +67,11 @@ const settings = {
 }
 
 /**
- * phpPathは環境に合わせてどちらかをコメントアウトする
+ * phpPath
+ * windowsまたはphpのバージョンを指定したい場合はpathを指定
+ * 例：const phpPath = 'C:/PATH/TO/YOUR/php.exe'
  */
-// mac,linuxで既にphpがインストールしてある場合
-const phpPath = undefined
-
-// windowsまたはphpのバージョンを指定したい場合
-// const phpPath = 'C:/PATH/TO/YOUR/php.exe'
+const phpPath = 'php'
 
 // setting update
 const argv = minimist(process.argv.slice(2))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amiten-plate",
   "description": "for all",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "bugs": {
     "email": "amishiro@amiten.co.jp"
   },


### PR DESCRIPTION
windows環境ではphpのバイナリ指定が必須の為、設定項目を作成。
絶対パスで指定しないと挙動が怪しい事に注意。
PHPのバージョン管理にもなるため、他環境でも使ったほうが良さそう。